### PR TITLE
Update the format on the countdown timer to use "d" for Days

### DIFF
--- a/countdown-timer/countdown-timer.js
+++ b/countdown-timer/countdown-timer.js
@@ -38,8 +38,8 @@
 
 		let $timeValue = "";
 
-		if ($duration.asDays() > 0) {
-			$timeValue += Math.trunc($duration.asDays()).toString().padStart(2, "0") + ":";
+		if ($duration.asDays() >= 1) {
+            $timeValue += Math.trunc($duration.asDays()).toString() + "d ";
 		}
 
 		$timeValue += $duration.hours().toString().padStart(2, "0") + ":";


### PR DESCRIPTION
I find the extra colon confusing, and ISO time period formats seem to lean towards using letter separators indicating the units when talking about anything larger than hours/minutes/seconds.